### PR TITLE
add: window command to clear current file

### DIFF
--- a/AutoFoldCode.py
+++ b/AutoFoldCode.py
@@ -3,7 +3,10 @@ import sublime_plugin
 
 import os
 
-# Called at sublime startup, restore folded regions for each view
+# File name that our plugin data is saved under.
+__storage_file__ = 'AutoFoldCode.sublime-settings'
+
+# Called at sublime startup: restore folded regions for each view.
 def plugin_loaded():
   for window in sublime.windows():
     for view in window.views():
@@ -18,45 +21,61 @@ def restore_folds(view):
     for a, b in saved_regions:
       view.fold(sublime.Region(a, b))
 
-# File name that our plugin data is saved under.
-__storage_file__ = 'AutoFoldCode.sublime-settings'
+# Save the folded regions to disk.
+def save_folds(view):
+  s = sublime.load_settings(__storage_file__)
+  regions_to_save = [(r.a, r.b) for r in view.folded_regions()]
 
-class AutoFoldCode(sublime_plugin.EventListener):
+  # Save the folded regions.
+  if regions_to_save:
+    s.set(view.file_name(), regions_to_save)
+    sublime.save_settings(__storage_file__)
+
+# Clears the cache. If name is '*', it will clear the whole cache.
+# Otherwise, pass in the file_name of the view to clear the view's cache.
+def clear_cache(name):
+  # Load the settings.
+  settings = sublime.load_settings(__storage_file__)
+  # Read the file (to get the keys).
+  f = sublime.load_resource(os.path.join('Packages', 'User', __storage_file__))
+  try:
+    for file_name in sublime.decode_value(f):
+      if name == '*' or file_name == name:
+        settings.erase(file_name)
+  except Exception as e:
+    print('[AutoFoldCode.clear] Error loading settings file.')
+    print(e)
+  # Flush changes to disk.
+  sublime.save_settings(__storage_file__)
+
+class AutoFoldCodeListener(sublime_plugin.EventListener):
   # Restore folded regions when each file is opened.
   def on_load_async(self, view):
     restore_folds(view)
 
-  # Save the folded regions to disk.
-  def save_regions(self, view):
-    s = sublime.load_settings(__storage_file__)
-    regions_to_save = [(r.a, r.b) for r in view.folded_regions()]
-
-    # Save the folded regions.
-    if regions_to_save:
-      s.set(view.file_name(), regions_to_save)
-      sublime.save_settings(__storage_file__)
-
   # Save regions when file is saved.
   def on_post_save_async(self, view):
-    self.save_regions(view);
+    save_folds(view);
 
   # Save regions when file is closed.
   def on_close(self, view):
-    self.save_regions(view);
+    save_folds(view);
 
-
-# A window command that clears all the saved code folds.
-class AutoFoldCodeClearCommand(sublime_plugin.WindowCommand):
+# Clears all the saved code folds.
+class AutoFoldCodeClearAllCommand(sublime_plugin.WindowCommand):
   def run(self):
-    # Load the settings.
-    settings = sublime.load_settings(__storage_file__)
-    # Read the file (to get the keys).
-    f = sublime.load_resource(os.path.join('Packages', 'User', __storage_file__))
-    try:
-      # For each key (file_name), erase the value (folded regions).
-      for key in sublime.decode_value(f):
-        settings.erase(key)
-    except:
-      print('[AutoFoldCode.clear] Error loading settings file.')
-    # Flush changes to disk.
-    sublime.save_settings(__storage_file__)
+    clear_cache('*')
+
+# Clears the cache for the current view, and unfolds all its regions.
+class AutoFoldCodeClearCurrentCommand(sublime_plugin.WindowCommand):
+  def run(self):
+    view = self.window.active_view()
+    file_name = view.file_name()
+    if view and file_name:
+      view.unfold(sublime.Region(0, view.size()))
+      clear_cache(file_name)
+
+  def is_enabled(self):
+    view = self.window.active_view()
+    file_name = view.file_name()
+    return view != None and file_name != None

--- a/AutoFoldCode.sublime-commands
+++ b/AutoFoldCode.sublime-commands
@@ -1,3 +1,4 @@
 [
-  { "caption": "AutoFoldCode: Clear", "command": "auto_fold_code_clear" },
+  { "caption": "AutoFoldCode: Clear All", "command": "auto_fold_code_clear_all" },
+  { "caption": "AutoFoldCode: Clear Current File", "command": "auto_fold_code_clear_current" }
 ]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@ Thank you for checking this out, if you want to support what I do you might [buy
 2. Search for `AutoFoldCode` and install.
 
 ## Usage
-Once installed, AutoFoldCode will automatically begin persisting code folds. To clear AutoFoldCode's cache, use the `AutoFoldCode: Clear` command from the Command Palette.
+Once installed, AutoFoldCode will automatically begin persisting code folds.
+
+AutoFoldCode also includes some useful commands:
+
+* `AutoFoldCode: Clear All`
+	- This command will clear AutoFoldCode's cache.
+* `AutoFoldCode: Clear Current File`
+	- This command will remove the current file's folded regions from the cache, and unfold all folded regions in the file.
 
 ## Authors
 Originally developed by @callodacity, now it's being mantained by me.


### PR DESCRIPTION
This PR adds another window command: `AutoFoldCode: Clear Current File`.

It's nice in case the user ever wants to clear all the folds of the current file, but not the folds of other files as well.