### PR TITLE
feat: unfold commands

### DIFF
--- a/AutoFoldCode.py
+++ b/AutoFoldCode.py
@@ -58,16 +58,13 @@ class AutoFoldCodeUnfoldAllCommand(sublime_plugin.WindowCommand):
 #   Helpers   #
 # ----------- #
 
-# Restore all the saved folds.
+# Restore the saved folds for the given view.
 def _restore_folds(view):
   settings = sublime.load_settings(__storage_file__)
-  regions = settings.get(view.file_name(), [])
+  for a, b in settings.get(view.file_name(), []):
+    view.fold(sublime.Region(a, b))
 
-  if regions:
-    for a, b in regions:
-      view.fold(sublime.Region(a, b))
-
-# Save the folded regions to disk.
+# Save the folded regions of the view to disk.
 def _save_folds(view):
   settings = sublime.load_settings(__storage_file__)
   regions = [(r.a, r.b) for r in view.folded_regions()]
@@ -87,7 +84,7 @@ def _clear_cache(name):
       if name == '*' or file_name == name:
         settings.erase(file_name)
   except Exception as e:
-    print('[AutoFoldCode.clear] Error loading settings file.')
+    print('[AutoFoldCode._clear_cache] Error loading settings file:')
     print(e)
   # Flush changes to disk.
   sublime.save_settings(__storage_file__)

--- a/AutoFoldCode.py
+++ b/AutoFoldCode.py
@@ -10,7 +10,8 @@ __storage_path__ = os.path.join('Packages', 'User', __storage_file__)
 def plugin_loaded():
   for window in sublime.windows():
     for view in window.views():
-      _restore_folds(view)
+      if view.file_name():
+        _restore_folds(view)
 
 # Listen to changes in views to automatically save code folds.
 class AutoFoldCodeListener(sublime_plugin.EventListener):
@@ -22,6 +23,10 @@ class AutoFoldCodeListener(sublime_plugin.EventListener):
 
   def on_close(self, view):
     _save_folds(view)
+
+  def on_text_command(self, view, command_name, args):
+    if command_name == 'unfold_all' and view.file_name() != None:
+      _clear_cache(view.file_name())
 
 # ------------------- #
 #   Window Commands   #

--- a/AutoFoldCode.py
+++ b/AutoFoldCode.py
@@ -61,6 +61,10 @@ class AutoFoldCodeListener(sublime_plugin.EventListener):
   def on_close(self, view):
     save_folds(view);
 
+# --------------- #
+# Window Commands #
+# --------------- #
+
 # Clears all the saved code folds.
 class AutoFoldCodeClearAllCommand(sublime_plugin.WindowCommand):
   def run(self):
@@ -79,3 +83,10 @@ class AutoFoldCodeClearCurrentCommand(sublime_plugin.WindowCommand):
     view = self.window.active_view()
     file_name = view.file_name()
     return view != None and file_name != None
+
+# Unfold all code folds in all open files.
+class AutoFoldCodeUnfoldAllCommand(sublime_plugin.WindowCommand):
+  def run(self):
+    for window in sublime.windows():
+      for view in window.views():
+        view.unfold(sublime.Region(0, view.size()))

--- a/AutoFoldCode.py
+++ b/AutoFoldCode.py
@@ -68,10 +68,8 @@ def _restore_folds(view):
 def _save_folds(view):
   settings = sublime.load_settings(__storage_file__)
   regions = [(r.a, r.b) for r in view.folded_regions()]
-
-  if regions:
-    settings.set(view.file_name(), regions)
-    sublime.save_settings(__storage_file__)
+  settings.set(view.file_name(), regions)
+  sublime.save_settings(__storage_file__)
 
 # Clears the cache. If name is '*', it will clear the whole cache.
 # Otherwise, pass in the file_name of the view to clear the view's cache.

--- a/AutoFoldCode.py
+++ b/AutoFoldCode.py
@@ -65,9 +65,10 @@ class AutoFoldCodeListener(sublime_plugin.EventListener):
 # Window Commands #
 # --------------- #
 
-# Clears all the saved code folds.
+# Clears all the saved code folds and unfolds all the currently open windows.
 class AutoFoldCodeClearAllCommand(sublime_plugin.WindowCommand):
   def run(self):
+    self.window.run_command('auto_fold_code_unfold_all')
     clear_cache('*')
 
 # Clears the cache for the current view, and unfolds all its regions.

--- a/AutoFoldCode.py
+++ b/AutoFoldCode.py
@@ -37,15 +37,13 @@ class AutoFoldCodeClearAllCommand(sublime_plugin.WindowCommand):
 class AutoFoldCodeClearCurrentCommand(sublime_plugin.WindowCommand):
   def run(self):
     view = self.window.active_view()
-    file_name = view.file_name()
-    if view and file_name:
+    if view and view.file_name():
       view.unfold(sublime.Region(0, view.size()))
-      _clear_cache(file_name)
+      _clear_cache(view.file_name())
 
   def is_enabled(self):
     view = self.window.active_view()
-    file_name = view.file_name()
-    return view != None and file_name != None
+    return view != None and view.file_name() != None
 
 # Unfold all code folds in all open files.
 class AutoFoldCodeUnfoldAllCommand(sublime_plugin.WindowCommand):

--- a/AutoFoldCode.py
+++ b/AutoFoldCode.py
@@ -1,75 +1,37 @@
+import os
 import sublime
 import sublime_plugin
 
-import os
-
-# File name that our plugin data is saved under.
+# File name/path where the plugin data is saved.
 __storage_file__ = 'AutoFoldCode.sublime-settings'
+__storage_path__ = os.path.join('Packages', 'User', __storage_file__)
 
 # Called at sublime startup: restore folded regions for each view.
 def plugin_loaded():
   for window in sublime.windows():
     for view in window.views():
-      restore_folds(view)
+      _restore_folds(view)
 
-# Restore all the saved folds.
-def restore_folds(view):
-  s = sublime.load_settings(__storage_file__)
-  saved_regions = s.get(view.file_name(), [])
-
-  if saved_regions:
-    for a, b in saved_regions:
-      view.fold(sublime.Region(a, b))
-
-# Save the folded regions to disk.
-def save_folds(view):
-  s = sublime.load_settings(__storage_file__)
-  regions_to_save = [(r.a, r.b) for r in view.folded_regions()]
-
-  # Save the folded regions.
-  if regions_to_save:
-    s.set(view.file_name(), regions_to_save)
-    sublime.save_settings(__storage_file__)
-
-# Clears the cache. If name is '*', it will clear the whole cache.
-# Otherwise, pass in the file_name of the view to clear the view's cache.
-def clear_cache(name):
-  # Load the settings.
-  settings = sublime.load_settings(__storage_file__)
-  # Read the file (to get the keys).
-  f = sublime.load_resource(os.path.join('Packages', 'User', __storage_file__))
-  try:
-    for file_name in sublime.decode_value(f):
-      if name == '*' or file_name == name:
-        settings.erase(file_name)
-  except Exception as e:
-    print('[AutoFoldCode.clear] Error loading settings file.')
-    print(e)
-  # Flush changes to disk.
-  sublime.save_settings(__storage_file__)
-
+# Listen to changes in views to automatically save code folds.
 class AutoFoldCodeListener(sublime_plugin.EventListener):
-  # Restore folded regions when each file is opened.
   def on_load_async(self, view):
-    restore_folds(view)
+    _restore_folds(view)
 
-  # Save regions when file is saved.
   def on_post_save_async(self, view):
-    save_folds(view);
+    _save_folds(view)
 
-  # Save regions when file is closed.
   def on_close(self, view):
-    save_folds(view);
+    _save_folds(view)
 
-# --------------- #
-# Window Commands #
-# --------------- #
+# ------------------- #
+#   Window Commands   #
+# ------------------- #
 
 # Clears all the saved code folds and unfolds all the currently open windows.
 class AutoFoldCodeClearAllCommand(sublime_plugin.WindowCommand):
   def run(self):
+    _clear_cache('*')
     self.window.run_command('auto_fold_code_unfold_all')
-    clear_cache('*')
 
 # Clears the cache for the current view, and unfolds all its regions.
 class AutoFoldCodeClearCurrentCommand(sublime_plugin.WindowCommand):
@@ -78,7 +40,7 @@ class AutoFoldCodeClearCurrentCommand(sublime_plugin.WindowCommand):
     file_name = view.file_name()
     if view and file_name:
       view.unfold(sublime.Region(0, view.size()))
-      clear_cache(file_name)
+      _clear_cache(file_name)
 
   def is_enabled(self):
     view = self.window.active_view()
@@ -91,3 +53,41 @@ class AutoFoldCodeUnfoldAllCommand(sublime_plugin.WindowCommand):
     for window in sublime.windows():
       for view in window.views():
         view.unfold(sublime.Region(0, view.size()))
+
+# ----------- #
+#   Helpers   #
+# ----------- #
+
+# Restore all the saved folds.
+def _restore_folds(view):
+  settings = sublime.load_settings(__storage_file__)
+  regions = settings.get(view.file_name(), [])
+
+  if regions:
+    for a, b in regions:
+      view.fold(sublime.Region(a, b))
+
+# Save the folded regions to disk.
+def _save_folds(view):
+  settings = sublime.load_settings(__storage_file__)
+  regions = [(r.a, r.b) for r in view.folded_regions()]
+
+  if regions:
+    settings.set(view.file_name(), regions)
+    sublime.save_settings(__storage_file__)
+
+# Clears the cache. If name is '*', it will clear the whole cache.
+# Otherwise, pass in the file_name of the view to clear the view's cache.
+def _clear_cache(name):
+  # Read the file (to get it as a dict).
+  json = sublime.load_resource(__storage_path__)
+  settings = sublime.load_settings(__storage_file__)
+  try:
+    for file_name in sublime.decode_value(json):
+      if name == '*' or file_name == name:
+        settings.erase(file_name)
+  except Exception as e:
+    print('[AutoFoldCode.clear] Error loading settings file.')
+    print(e)
+  # Flush changes to disk.
+  sublime.save_settings(__storage_file__)

--- a/AutoFoldCode.sublime-commands
+++ b/AutoFoldCode.sublime-commands
@@ -1,4 +1,5 @@
 [
   { "caption": "AutoFoldCode: Clear All", "command": "auto_fold_code_clear_all" },
-  { "caption": "AutoFoldCode: Clear Current File", "command": "auto_fold_code_clear_current" }
+  { "caption": "AutoFoldCode: Clear Current File", "command": "auto_fold_code_clear_current" },
+  { "caption": "AutoFoldCode: Unfold All Open Files", "command": "auto_fold_code_unfold_all" }
 ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ AutoFoldCode also includes some useful commands:
 	- This command will clear AutoFoldCode's cache.
 * `AutoFoldCode: Clear Current File`
 	- This command will remove the current file's folded regions from the cache, and unfold all folded regions in the file.
+* `AutoFoldCode: Unfold All Open Files`
+	- This unfolds all open files in all open windows.
+	- If you want to just unfold just the current file, Sublime Text already includes the `"unfold_all"` command for this.
 
 ## Authors
 Originally developed by @callodacity, now it's being mantained by me.


### PR DESCRIPTION
This PR adds in the extra command `AutoFoldCode: Unfold All Open Files`. Sublime Text already has a command to unfold the current file, so we don't need to implement that command.

Also, this updates the `AutoFoldCode: Clear All` command, so that it unfolds all folded regions in all open views as well (before it would just clear the cache, and if you ran `Clear All` without unfolding the regions then it would re-cache the folded regions).

It also make some changes to the code:

* All non-exported functions are prefixed with `_`
    - This is to make the code clearer, we want `plugin_loaded` to be exported, but none of the other functions need to be exported. So, since they're file-specific, why not make the code clear and reflect that?
* Restructured the source code for clarity
    - This groups the window commands together, and moves the helpers to the bottom. Why not make the source code easier to understand and read?
* Other bug fixes:
    - If there were no folded regions and the user saved, then AutoFoldCode would not update its cache.
    - A error would be thrown if some commands were executed without there being an active view in a window.
    - Fixed an error when `plugin_loaded` is called when there are unnamed views (like Find Results, etc)