### PR TITLE
feat: save selections

### DIFF
--- a/AutoFoldCode.sublime-settings
+++ b/AutoFoldCode.sublime-settings
@@ -6,10 +6,16 @@
   // slowing down your editing).
   "max_buffer_size": 1000000,
 
+  // Should AutoFoldCode save and restore your selections inside the editor?
+  "save_selections": true,
+
   // INTERNAL STORAGE FOR AUTOFOLDCODE -----------------------------------------
 
   // Your code folds are stored in this value.
   "folds": {},
+
+  // Saved selections if enabled.
+  "selections": {},
 
   // ATTENTION: DO NOT EDIT THIS VALUE
   // This is used by AutoFoldCode to check the storage version format of your

--- a/messages.json
+++ b/messages.json
@@ -3,5 +3,6 @@
  "1.1.1": "messages/1.1.1.txt",
  "1.2.0": "messages/1.2.0.txt",
  "1.3.0": "messages/1.3.0.txt",
+ "1.4.0": "messages/1.4.0.txt",
  "install": "messages/install.txt"
 }

--- a/messages/1.4.0.txt
+++ b/messages/1.4.0.txt
@@ -1,0 +1,7 @@
+# 1.4.0
+
+Changes:
+
+* Feature: AutoFoldCode now remembers your selections inside each file!
+  This means that when you close and re-open a file, your selections will be restored.
+  This behaviour can be disabled with the `save_selections: <boolean>` setting.


### PR DESCRIPTION
This PR adds in the ability to save selections as well as code folds.
It works exactly as before, but also adds a configurable option: `save_selections: <boolean>` which defaults to `true`.

Closes #14 